### PR TITLE
Update getCookie to reflect optional return value

### DIFF
--- a/src/cypress.res
+++ b/src/cypress.res
@@ -281,8 +281,8 @@ let screenshot = (cy, a, ~log=?, ~timeout=?, ~blackout=?, ~capture=?, ~clip=?, ~
 @send external exec: (cy<root>, string) => unit = "exec"
 @send external end: cy<'a> => unit = "end"
 
-type cookie = {value: string}
-@send external getCookie: (cy<root>, string) => cy<cookie> = "getCookie"
+type cookie = {name: string, value: string}
+@send external getCookie: (cy<root>, string) => cy<option<cookie>> = "getCookie"
 
 @send external clearCookies: cy<root> => unit = "clearCookies"
 


### PR DESCRIPTION
The Cypress library getCookie method returns an optional cookie - https://docs.cypress.io/api/commands/getcookie#When-a-cookie-matching-the-name-could-not-be-found